### PR TITLE
Tried more experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CIFAR-10 is a classic computer vision dataset consisting of 60,000 32x32 color i
   - USE_BN=True, momentum=0.9, lr=0.01 (or retune)
   - On CPU, BN increases epoch time. On GPU, BN is much faster and can help accuracy.
 - Cosine schedule:
-  - USE_COSINE=True with fixed EPOCHS; consider warmup or longer training for benefit
+  - USE_COSINE=True with fixed EPOCHS; consider warmup or longer training for benefit. Recent run with lr=0.02, momentum=0.9, cosine over 10 epochs achieved 71.78% on CPU.
 
 Refer to experiments.md for exact runs:
 - Adam vs SGD (Run 7a/7b): Adam did not beat tuned SGD in final accuracy for this small CNN.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,23 @@
 
 This repository is dedicated to learning and building intuition for neural networks by "speedrunning" the CIFAR-10 dataset.
 
+## TL;DR (Quick Start)
+- Single script: main.py
+- Default strong CPU baseline: SimpleCNN, SGD(lr=0.02, momentum=0.9), 10 epochs, no BN/augmentation
+- Reproducible toggles in code:
+  - USE_BN = False  # add BatchNorm if True
+  - USE_COSINE = False  # cosine LR schedule over EPOCHS if True
+- Latest best CPU result (no aug): 71.87% in ~197s (see experiments.md Run 8f)
+- All experiment logs with per-epoch metrics: experiments.md
+
+Run locally:
+```
+python main.py
+```
+
 ## The Philosophy: Learn by Iterating, Fast
+
+We shorten the idea-to-result loop to minutes. CIFAR-10 plus a tiny CNN gives fast feedback so you can isolate one change at a time and build intuition.
 
 The core idea, inspired by practitioners like Keller Jordan, is that the speed of learning is limited by the time it takes to go from a new idea to a concrete result. Traditional machine learning workflows can involve long training times, making it difficult to connect a specific change to its outcome.
 
@@ -16,71 +32,43 @@ CIFAR-10 is a classic computer vision dataset consisting of 60,000 32x32 color i
 
 `airplane`, `automobile`, `bird`, `cat`, `deer`, `dog`, `frog`, `horse`, `ship`, `truck`
 
-It's the perfect "gym" for this project—complex enough to be interesting, but small enough to enable lightning-fast training on a modern GPU.
+## Current Onboarding: What this repo gives you
+1) A runnable baseline that trains end-to-end in a few minutes on CPU.
+2) A minimal model with switches to compare common techniques (BatchNorm, cosine schedule).
+3) A living lab notebook: experiments.md with hypotheses, configs, timings, and per-epoch accuracy.
 
-## The Plan of Attack
+## How to reproduce the main baselines
+- Baseline (fast, CPU-friendly):
+  - In main.py: USE_BN=False, USE_COSINE=False, LEARNING_RATE=0.02, momentum=0.9
+  - Command: `python main.py`
+  - Expected: ~71–72% in ~19–20s/epoch on CPU
+- BatchNorm variant (slower on CPU, faster on GPU):
+  - USE_BN=True, momentum=0.9, lr=0.01 (or retune)
+  - On CPU, BN increases epoch time. On GPU, BN is much faster and can help accuracy.
+- Cosine schedule:
+  - USE_COSINE=True with fixed EPOCHS; consider warmup or longer training for benefit
 
-We will approach this in a structured, scientific manner. For each change, we will form a hypothesis, run the experiment, and analyze the results.
+Refer to experiments.md for exact runs:
+- Adam vs SGD (Run 7a/7b): Adam did not beat tuned SGD in final accuracy for this small CNN.
+- BN on CPU (Run 8/8b): BN without momentum underperformed; BN+momentum improved accuracy but was slower on CPU.
+- Momentum alone (Run 8c): Solid gains with low overhead; best CPU trade-off.
+- Weight decay and cosine (Run 8d/8e): Did not beat fixed LR momentum in 10 epochs.
+- Raised LR (Run 8f): lr=0.02 with momentum=0.9 achieved 71.87% on CPU without BN.
 
-### Phase 0: Setup
+## Suggested next experiments
+- Add simple augmentation (RandomCrop(32, padding=4), RandomHorizontalFlip) to push >75% without changing model depth.
+- GPU pass: re-evaluate BN on GPU (much faster kernels). Expect better speed and potentially accuracy.
+- LR/momentum small sweep around the current best: lr ∈ {0.015, 0.02, 0.025}, momentum ∈ {0.8, 0.9, 0.95}.
+- Optional optimizer baseline: AdamW(lr=1e-3, wd=5e-4) for completeness.
 
-1.  **Environment**: Create a Python environment. This project will use `PyTorch` for its flexibility and `torchvision` for easy data loading. A GPU is highly recommended (Google Colab is a great free option).
-2.  **Experiment Tracking**: While you can start with notebooks, it's highly recommended to use a tool like **Weights & Biases** to log and compare results. It's free for personal use and invaluable for this kind of high-iteration workflow.
-3.  **Codebase**: Create a clean, simple Python script (`main.py`) that handles data loading, model definition, training, and validation. The goal is to have a single place to make quick modifications.
+## Environment setup
+- Python 3.10+
+- pip install torch torchvision (or use Conda)
+- GPU optional but recommended for BN and future augmentation-heavy experiments
 
-### Phase 1: The Baseline
-
-The first goal is to establish a simple, fast, and reliable baseline. This is the "control" against which all future experiments will be measured.
-
-*   **Action**:
-    *   **Model**: A simple CNN with 2-3 convolutional layers, max pooling, and 1-2 fully connected layers.
-    *   **Optimizer**: `torch.optim.SGD` (Stochastic Gradient Descent) with a fixed learning rate (e.g., `0.01`) and momentum (e.g., `0.9`).
-    *   **Data Augmentation**: None. Just a simple tensor conversion and normalization.
-    *   **Epochs**: 10 epochs.
-*   **Hypothesis**:
-    *   **Reasoning**: This is the most basic setup. SGD is a workhorse optimizer, but without any learning rate scheduling or data augmentation, the model will likely learn the training set reasonably well but won't generalize perfectly to the test set. It might also get stuck or converge slowly.
-    *   **Expected Result**: Training should complete in under 60 seconds. We'll likely see an accuracy of around **70-75%**. The validation loss will probably start to flatten or even increase towards the end, indicating the onset of overfitting.
-
-### Phase 2: Systematic Experimentation
-
-Now, we will change **one variable at a time** and compare it to the baseline.
-
-#### Experiment 2.1: The Optimizer
-
-*   **Action**: Change the optimizer from `SGD` to `torch.optim.Adam`. Keep the learning rate the same initially (`0.01`).
-*   **Hypothesis**:
-    *   **Reasoning**: Adam is an adaptive optimizer that maintains a per-parameter learning rate. It often converges much faster than SGD in the initial epochs. However, its aggressive nature can sometimes lead it to a sharper, less generalizable minimum.
-    *   **Expected Result**: The model will train faster, achieving a higher accuracy in fewer epochs. The final accuracy might be slightly higher or lower than SGD, but the "area under the curve" for the accuracy plot will be much better. We might need to lower the learning rate, as Adam can be sensitive to high initial rates.
-
-#### Experiment 2.2: Batch Normalization
-
-*   **Action**: Revert to the baseline `SGD` optimizer. Add `nn.BatchNorm2d` layers after each convolutional layer in the model.
-*   **Hypothesis**:
-    *   **Reasoning**: Batch Normalization stabilizes the network by normalizing the inputs to each layer. This has a regularizing effect and allows for much higher learning rates without the training becoming unstable.
-    *   **Expected Result**: A significant improvement in both training speed and final accuracy. The model should train much more stably, and the final accuracy should jump by **5-10%**. This will likely be one of the most impactful changes we make.
-
-#### Experiment 2.3: Data Augmentation
-
-*   **Action**: Using the Batch Norm model from the previous step, add `transforms.RandomHorizontalFlip` and `transforms.RandomCrop` (with padding) to the training data transformations.
-*   **Hypothesis**:
-    *   **Reasoning**: Data augmentation artificially expands the dataset by creating modified versions of the training images. This forces the model to learn more robust and general features, making it less likely to overfit.
-    *   **Expected Result**: Training time per epoch will increase slightly due to the transformations. The training accuracy might increase more slowly, but the **validation accuracy should be significantly higher** and more stable over time. This is a powerful regularization technique. The gap between training and validation loss should be smaller.
-
-#### Experiment 2.4: Learning Rate Scheduling
-
-*   **Action**: Using the best model so far (with Batch Norm and Augmentation), add a learning rate scheduler, such as `torch.optim.lr_scheduler.OneCycleLR`. This scheduler starts with a low learning rate, warms up to a high one, and then anneals down.
-*   **Hypothesis**:
-    *   **Reasoning**: A fixed learning rate is a compromise. It's often too high at the end of training (preventing convergence to the best minimum) and could be higher at the beginning. `OneCycleLR` is known to provide very fast convergence and excellent regularization.
-    *   **Expected Result**: This should provide the best results yet. We should see faster convergence and potentially reach a new peak accuracy, possibly **over 90%**, even within just 10-20 epochs.
-
-### Phase 3: Pushing the Limits
-
-Once you are comfortable with the above, try more advanced experiments:
-
-*   **Architectural Changes**: Add dropout, increase the model depth or width, or try a simple ResNet block.
-*   **Advanced Optimizers**: Try newer optimizers like `LAdam` or `RAdam`.
-*   **CutMix / MixUp**: Implement more advanced data augmentation strategies.
-
-By the end of this process, you will not just have a model that classifies images; you will have a deep, intuitive sense of what makes a neural network learn effectively.
+## Why this structure?
+- One-file training loop lowers friction and highlights cause/effect of each change.
+- experiments.md documents “what happened and why” so you can learn from every run.
+- Small steps, real measurements, fast iteration.
 
 **Happy Speedrunning!**

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Refer to experiments.md for exact runs:
 - LR/momentum small sweep around the current best: lr ∈ {0.015, 0.02, 0.025}, momentum ∈ {0.8, 0.9, 0.95}.
 - Optional optimizer baseline: AdamW(lr=1e-3, wd=5e-4) for completeness.
 
+### Pushing the Limits
+Once you are comfortable with the above, try more advanced experiments:
+- Architectural Changes: Add dropout, increase the model depth or width, or try a simple ResNet block.
+- Advanced Optimizers: Try newer optimizers like LAdam or RAdam.
+- CutMix / MixUp: Implement more advanced data augmentation strategies.
+
 ## Environment setup
 - Python 3.10+
 - pip install torch torchvision (or use Conda)

--- a/experiments.md
+++ b/experiments.md
@@ -270,3 +270,30 @@ Final Validation Accuracy: 70.57%
 ```
 
 **Analysis**: Momentum alone (no BN) restores accuracy to ~70.6% and keeps epoch time close to the faster, pre-BN runs (~20–22s). Conclusion: on CPU, BN adds notable overhead and didn’t help accuracy in this small CNN, while momentum=0.9 provides a clear benefit with minimal time cost. On GPU, BN would likely be faster and may still help; locally on CPU, prefer plain CNN + momentum for speed/accuracy trade-off.
+
+### Run 8d: No BN, SGD momentum=0.9, weight_decay=5e-4 (CPU)
+- **Hypothesis**: Adding standard weight decay should improve generalization slightly over momentum-only.
+- **Description**: USE_BN=False, optimizer=SGD(lr=0.01, momentum=0.9, weight_decay=5e-4), BATCH_SIZE=512, EPOCHS=10.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: Plain SimpleCNN (no BN), SGD(lr=0.01, momentum=0.9, wd=5e-4), BATCH_SIZE=512, EPOCHS=10.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 14.55 seconds.
+Epoch [1/10], Loss: 1.8833, Val Accuracy: 43.24%, Duration: 18.46s
+Epoch [2/10], Loss: 1.4400, Val Accuracy: 51.42%, Duration: 19.06s
+Epoch [3/10], Loss: 1.2625, Val Accuracy: 56.84%, Duration: 19.33s
+Epoch [4/10], Loss: 1.1499, Val Accuracy: 59.50%, Duration: 19.92s
+Epoch [5/10], Loss: 1.0612, Val Accuracy: 63.00%, Duration: 19.03s
+Epoch [6/10], Loss: 0.9716, Val Accuracy: 65.18%, Duration: 19.60s
+Epoch [7/10], Loss: 0.9192, Val Accuracy: 65.83%, Duration: 19.68s
+Epoch [8/10], Loss: 0.8637, Val Accuracy: 67.28%, Duration: 19.61s
+Epoch [9/10], Loss: 0.8058, Val Accuracy: 67.04%, Duration: 19.71s
+Epoch [10/10], Loss: 0.7546, Val Accuracy: 69.29%, Duration: 18.89s
+Finished Training. Training loop time: 193.29 seconds
+Final Validation Accuracy: 69.29%
+```
+
+**Analysis**: With weight decay, final accuracy here slightly underperformed momentum-only (~69.3% vs ~70.6%) on this run, though differences can be within run-to-run variance. Time remained in the faster ~19–20s/epoch band without BN. Next, consider trying cosine LR scheduling or tuning weight_decay (e.g., 1e-4 to 5e-4) to see if accuracy improves, or run multiple seeds to reduce variance effects.

--- a/experiments.md
+++ b/experiments.md
@@ -216,3 +216,30 @@ Final Validation Accuracy: 63.36%
 ```
 
 **Analysis**: On CPU, adding BatchNorm2d increased per-epoch time substantially and reduced final accuracy relative to the previous CPU baseline (~70%). Likely causes: BN kernels are slower on CPU; momentum was not used (BN often pairs well with SGD+momentum); hyperparameters not re-tuned for BN. Next steps: test SGD+momentum=0.9 with BN, and/or run on GPU where BN is much faster.
+
+### Run 8b: BatchNorm2d + SGD Momentum=0.9 (CPU)
+- **Hypothesis**: Adding momentum with BN should improve convergence and recover/beat baseline accuracy.
+- **Description**: Same as Run 8 (BN after conv1/conv2), but use SGD with momentum=0.9; lr=0.01; BATCH_SIZE=512; EPOCHS=10.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: SGD(lr=0.01, momentum=0.9), BATCH_SIZE=512, EPOCHS=10, BatchNorm2d after conv1/conv2.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 13.54 seconds.
+Epoch [1/10], Loss: 1.5025, Val Accuracy: 57.68%, Duration: 25.75s
+Epoch [2/10], Loss: 1.0837, Val Accuracy: 61.30%, Duration: 30.47s
+Epoch [3/10], Loss: 0.9392, Val Accuracy: 66.26%, Duration: 31.51s
+Epoch [4/10], Loss: 0.8598, Val Accuracy: 67.09%, Duration: 29.90s
+Epoch [5/10], Loss: 0.7828, Val Accuracy: 68.90%, Duration: 29.20s
+Epoch [6/10], Loss: 0.7239, Val Accuracy: 67.94%, Duration: 29.94s
+Epoch [7/10], Loss: 0.6749, Val Accuracy: 70.57%, Duration: 29.54s
+Epoch [8/10], Loss: 0.6353, Val Accuracy: 69.78%, Duration: 30.72s
+Epoch [9/10], Loss: 0.5773, Val Accuracy: 69.93%, Duration: 29.87s
+Epoch [10/10], Loss: 0.5345, Val Accuracy: 71.83%, Duration: 31.22s
+Finished Training. Training loop time: 298.13 seconds
+Final Validation Accuracy: 71.83%
+```
+
+**Analysis**: Momentum with BN restores and surpasses the earlier CPU baseline, reaching 71.83% final accuracy. However, CPU epoch times remain higher with BN (~29–31s vs ~20s without BN). Next isolation: test plain SGD + momentum=0.9 without BN to quantify momentum’s standalone contribution.

--- a/experiments.md
+++ b/experiments.md
@@ -188,3 +188,31 @@ Finished Training. Training loop time: 198.33 seconds
 Final Validation Accuracy: 66.69%
 ```
 **Analysis**: Adam shows faster initial convergence than SGD, but the final accuracy with lr=0.001 is only comparable to SGD, and lr=0.0004 underperforms. For this simple CNN on CIFAR-10, Adam does not outperform well-tuned SGD in final accuracy; tuning learning rate matters significantly.
+
+## Run 8: Add BatchNorm2d (CPU)
+- **Hypothesis**: BatchNorm should stabilize training and improve final accuracy.
+- **Description**: Insert BatchNorm2d after each conv layer: Conv -> BN -> ReLU -> Pool. Keep optimizer as plain SGD (no momentum), lr=0.01; BATCH_SIZE=512; EPOCHS=10. Same preloading and normalization as prior runs.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: SGD(lr=0.01, momentum=0.0), BATCH_SIZE=512, EPOCHS=10, BatchNorm2d after conv1/conv2.
+- **Observation**: Per-epoch time on CPU increased substantially with BN compared to prior CPU runs.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 15.01 seconds.
+Epoch [1/10], Loss: 1.8820, Val Accuracy: 44.49%, Duration: 29.67s
+Epoch [2/10], Loss: 1.5277, Val Accuracy: 49.90%, Duration: 31.31s
+Epoch [3/10], Loss: 1.3751, Val Accuracy: 53.62%, Duration: 31.14s
+Epoch [4/10], Loss: 1.2801, Val Accuracy: 54.82%, Duration: 33.10s
+Epoch [5/10], Loss: 1.2092, Val Accuracy: 56.85%, Duration: 31.33s
+Epoch [6/10], Loss: 1.1537, Val Accuracy: 59.29%, Duration: 30.15s
+Epoch [7/10], Loss: 1.1083, Val Accuracy: 60.32%, Duration: 32.39s
+Epoch [8/10], Loss: 1.0662, Val Accuracy: 61.13%, Duration: 31.49s
+Epoch [9/10], Loss: 1.0322, Val Accuracy: 60.05%, Duration: 31.42s
+Epoch [10/10], Loss: 1.0021, Val Accuracy: 63.36%, Duration: 32.57s
+Finished Training. Training loop time: 314.56 seconds
+Final Validation Accuracy: 63.36%
+```
+
+**Analysis**: On CPU, adding BatchNorm2d increased per-epoch time substantially and reduced final accuracy relative to the previous CPU baseline (~70%). Likely causes: BN kernels are slower on CPU; momentum was not used (BN often pairs well with SGD+momentum); hyperparameters not re-tuned for BN. Next steps: test SGD+momentum=0.9 with BN, and/or run on GPU where BN is much faster.

--- a/experiments.md
+++ b/experiments.md
@@ -351,3 +351,31 @@ Final Validation Accuracy: 71.87%
 ```
 
 **Analysis**: Increasing LR to 0.02 with momentum=0.9 improves final accuracy to 71.87% while maintaining ~19–20s epochs on CPU. This now matches/exceeds the BN+momentum result but with better training speed locally. This appears to be the best CPU configuration so far for this small CNN without augmentation.
+
+
+## Run 8g: No BN, SGD lr=0.02, momentum=0.9 + Cosine LR (CPU)
+- Hypothesis: Re-enabling cosine with the stronger lr=0.02 + momentum=0.9 baseline may improve generalization over fixed LR within 10 epochs.
+- Description: USE_BN=False, optimizer=SGD(lr=0.02, momentum=0.9), CosineAnnealingLR with T_max=10; BATCH_SIZE=512, EPOCHS=10; no weight decay; same preloading pipeline.
+- Hardware: AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- Configuration: SimpleCNN (no BN), SGD(lr=0.02, momentum=0.9), cosine schedule (T_max=10), BATCH_SIZE=512, EPOCHS=10.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 14.11 seconds.
+Epoch [1/10], Loss: 1.7572, Val Accuracy: 50.25%, Duration: 19.60s
+Epoch [2/10], Loss: 1.3028, Val Accuracy: 58.27%, Duration: 18.36s
+Epoch [3/10], Loss: 1.1193, Val Accuracy: 63.13%, Duration: 20.31s
+Epoch [4/10], Loss: 0.9797, Val Accuracy: 66.50%, Duration: 20.42s
+Epoch [5/10], Loss: 0.8804, Val Accuracy: 67.77%, Duration: 20.26s
+Epoch [6/10], Loss: 0.7999, Val Accuracy: 69.43%, Duration: 21.53s
+Epoch [7/10], Loss: 0.7356, Val Accuracy: 70.84%, Duration: 18.70s
+Epoch [8/10], Loss: 0.6840, Val Accuracy: 70.95%, Duration: 18.48s
+Epoch [9/10], Loss: 0.6491, Val Accuracy: 71.72%, Duration: 18.62s
+Epoch [10/10], Loss: 0.6273, Val Accuracy: 71.78%, Duration: 18.55s
+Finished Training. Training loop time: 194.84 seconds
+Final Validation Accuracy: 71.78%
+```
+
+- Result: Cosine with lr=0.02, momentum=0.9 essentially matches the best fixed-LR baseline (71.78% vs 71.87%) with similar time (~195–197s total). Over only 10 epochs, cosine does not clearly outperform fixed LR; it may benefit more from longer horizons or a brief warmup. Next: consider EPOCHS=30–50, CosineAnnealingWarmRestarts, or modest LR sweeps.

--- a/experiments.md
+++ b/experiments.md
@@ -324,3 +324,30 @@ Final Validation Accuracy: 66.48%
 ```
 
 **Analysis**: Cosine schedule underperformed the fixed-LR momentum baseline on this architecture/dataset split (66.5% vs ~70–71%). Likely the LR decay was too aggressive over only 10 epochs with no warmup. If retrying cosine, consider either a higher initial LR (e.g., 0.02), a warmup epoch, or extending total epochs. For now, fixed LR=0.01 with momentum=0.9 (no BN) remains the best CPU speed/accuracy trade-off observed.
+
+### Run 8f: No BN, SGD lr=0.02, momentum=0.9 (CPU)
+- **Hypothesis**: A slightly higher LR with momentum may improve final accuracy within 10 epochs.
+- **Description**: USE_BN=False, fixed LR=0.02, momentum=0.9, no weight decay, no scheduler; BATCH_SIZE=512, EPOCHS=10.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: Plain SimpleCNN (no BN), SGD(lr=0.02, momentum=0.9), BATCH_SIZE=512, EPOCHS=10.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 14.00 seconds.
+Epoch [1/10], Loss: 1.7484, Val Accuracy: 49.95%, Duration: 20.78s
+Epoch [2/10], Loss: 1.2820, Val Accuracy: 57.25%, Duration: 19.96s
+Epoch [3/10], Loss: 1.0949, Val Accuracy: 63.43%, Duration: 19.67s
+Epoch [4/10], Loss: 0.9661, Val Accuracy: 66.19%, Duration: 19.12s
+Epoch [5/10], Loss: 0.8593, Val Accuracy: 68.32%, Duration: 19.21s
+Epoch [6/10], Loss: 0.7831, Val Accuracy: 69.16%, Duration: 19.38s
+Epoch [7/10], Loss: 0.7036, Val Accuracy: 70.45%, Duration: 20.24s
+Epoch [8/10], Loss: 0.6326, Val Accuracy: 71.18%, Duration: 20.01s
+Epoch [9/10], Loss: 0.5596, Val Accuracy: 71.32%, Duration: 19.22s
+Epoch [10/10], Loss: 0.4853, Val Accuracy: 71.87%, Duration: 19.72s
+Finished Training. Training loop time: 197.30 seconds
+Final Validation Accuracy: 71.87%
+```
+
+**Analysis**: Increasing LR to 0.02 with momentum=0.9 improves final accuracy to 71.87% while maintaining ~19–20s epochs on CPU. This now matches/exceeds the BN+momentum result but with better training speed locally. This appears to be the best CPU configuration so far for this small CNN without augmentation.

--- a/experiments.md
+++ b/experiments.md
@@ -243,3 +243,30 @@ Final Validation Accuracy: 71.83%
 ```
 
 **Analysis**: Momentum with BN restores and surpasses the earlier CPU baseline, reaching 71.83% final accuracy. However, CPU epoch times remain higher with BN (~29–31s vs ~20s without BN). Next isolation: test plain SGD + momentum=0.9 without BN to quantify momentum’s standalone contribution.
+
+### Run 8c: Remove BatchNorm, keep SGD Momentum=0.9 (CPU)
+- **Hypothesis**: Isolate the benefit of momentum alone without BN overhead.
+- **Description**: USE_BN=False (no BatchNorm), optimizer=SGD(lr=0.01, momentum=0.9), BATCH_SIZE=512, EPOCHS=10.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: Plain SimpleCNN (no BN), SGD(lr=0.01, momentum=0.9), BATCH_SIZE=512, EPOCHS=10.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 13.37 seconds.
+Epoch [1/10], Loss: 1.8987, Val Accuracy: 45.17%, Duration: 18.02s
+Epoch [2/10], Loss: 1.4286, Val Accuracy: 52.15%, Duration: 19.91s
+Epoch [3/10], Loss: 1.2547, Val Accuracy: 57.24%, Duration: 21.74s
+Epoch [4/10], Loss: 1.1336, Val Accuracy: 60.48%, Duration: 20.84s
+Epoch [5/10], Loss: 1.0397, Val Accuracy: 62.27%, Duration: 22.01s
+Epoch [6/10], Loss: 0.9639, Val Accuracy: 64.78%, Duration: 22.32s
+Epoch [7/10], Loss: 0.8949, Val Accuracy: 66.52%, Duration: 21.32s
+Epoch [8/10], Loss: 0.8293, Val Accuracy: 68.32%, Duration: 21.58s
+Epoch [9/10], Loss: 0.7829, Val Accuracy: 68.86%, Duration: 21.59s
+Epoch [10/10], Loss: 0.7235, Val Accuracy: 70.57%, Duration: 20.55s
+Finished Training. Training loop time: 209.88 seconds
+Final Validation Accuracy: 70.57%
+```
+
+**Analysis**: Momentum alone (no BN) restores accuracy to ~70.6% and keeps epoch time close to the faster, pre-BN runs (~20–22s). Conclusion: on CPU, BN adds notable overhead and didn’t help accuracy in this small CNN, while momentum=0.9 provides a clear benefit with minimal time cost. On GPU, BN would likely be faster and may still help; locally on CPU, prefer plain CNN + momentum for speed/accuracy trade-off.

--- a/experiments.md
+++ b/experiments.md
@@ -297,3 +297,30 @@ Final Validation Accuracy: 69.29%
 ```
 
 **Analysis**: With weight decay, final accuracy here slightly underperformed momentum-only (~69.3% vs ~70.6%) on this run, though differences can be within run-to-run variance. Time remained in the faster ~19–20s/epoch band without BN. Next, consider trying cosine LR scheduling or tuning weight_decay (e.g., 1e-4 to 5e-4) to see if accuracy improves, or run multiple seeds to reduce variance effects.
+
+### Run 8e: No BN, SGD momentum=0.9 + Cosine LR Schedule (CPU)
+- **Hypothesis**: Cosine annealing can improve generalization and final accuracy over a fixed LR.
+- **Description**: USE_BN=False, optimizer=SGD(lr=0.01, momentum=0.9), CosineAnnealingLR over 10 epochs, no weight decay; BATCH_SIZE=512, EPOCHS=10.
+- **Hardware:** AMD Ryzen 7 5700U with Radeon Graphics, WSL environment (CPU).
+- **Configuration**: Plain SimpleCNN (no BN), SGD(lr=0.01, momentum=0.9), cosine schedule (T_max=10), BATCH_SIZE=512, EPOCHS=10.
+
+```
+$ python main.py
+Using device: cpu
+Pre-loading data...
+Data pre-loaded in 12.73 seconds.
+Epoch [1/10], Loss: 1.8896, Val Accuracy: 45.53%, Duration: 17.93s
+Epoch [2/10], Loss: 1.4258, Val Accuracy: 52.42%, Duration: 19.47s
+Epoch [3/10], Loss: 1.2589, Val Accuracy: 56.44%, Duration: 19.08s
+Epoch [4/10], Loss: 1.1413, Val Accuracy: 59.26%, Duration: 19.20s
+Epoch [5/10], Loss: 1.0700, Val Accuracy: 62.27%, Duration: 19.67s
+Epoch [6/10], Loss: 0.9929, Val Accuracy: 64.11%, Duration: 20.19s
+Epoch [7/10], Loss: 0.9372, Val Accuracy: 65.37%, Duration: 18.95s
+Epoch [8/10], Loss: 0.9026, Val Accuracy: 65.57%, Duration: 19.87s
+Epoch [9/10], Loss: 0.8781, Val Accuracy: 65.94%, Duration: 20.12s
+Epoch [10/10], Loss: 0.8637, Val Accuracy: 66.48%, Duration: 19.34s
+Finished Training. Training loop time: 193.83 seconds
+Final Validation Accuracy: 66.48%
+```
+
+**Analysis**: Cosine schedule underperformed the fixed-LR momentum baseline on this architecture/dataset split (66.5% vs ~70–71%). Likely the LR decay was too aggressive over only 10 epochs with no warmup. If retrying cosine, consider either a higher initial LR (e.g., 0.02), a warmup epoch, or extending total epochs. For now, fixed LR=0.01 with momentum=0.9 (no BN) remains the best CPU speed/accuracy trade-off observed.

--- a/main.py
+++ b/main.py
@@ -119,8 +119,8 @@ def main():
 
     # --- 5. Loss Function and Optimizer ---
     criterion = nn.CrossEntropyLoss()
-    # Plain SGD with momentum=0.9 for isolation (BN toggled by USE_BN)
-    optimizer = optim.SGD(model.parameters(), lr=LEARNING_RATE, momentum=0.9)
+    # Plain SGD with momentum=0.9 and weight decay for regularization (BN toggled by USE_BN)
+    optimizer = optim.SGD(model.parameters(), lr=LEARNING_RATE, momentum=0.9, weight_decay=5e-4)
 
     # --- 6. Training and Validation Loop ---
     start_time = time.time()

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def main():
     BATCH_SIZE = 512
     EPOCHS = 10
     USE_BN = False  # Toggle BatchNorm on/off to isolate its effect
-    USE_COSINE = True  # Enable cosine annealing LR schedule
+    USE_COSINE = False  # Disable cosine annealing LR schedule (use fixed LR)
     
     print("Pre-loading data...")
     start_load_time = time.time()

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def main():
 
     # --- 2. Hyperparameters ---
     # These are the settings we will be tweaking in our experiments
-    LEARNING_RATE = 0.0004  # Standard Adam learning rate
+    LEARNING_RATE = 0.01  # Baseline SGD learning rate
     BATCH_SIZE = 512
     EPOCHS = 10
     
@@ -103,8 +103,8 @@ def main():
 
     # --- 5. Loss Function and Optimizer ---
     criterion = nn.CrossEntropyLoss()
-    # Experiment 2.1: Adam optimizer instead of SGD
-    optimizer = optim.Adam(model.parameters(), lr=LEARNING_RATE)
+    # Rollback to baseline optimizer
+    optimizer = optim.SGD(model.parameters(), lr=LEARNING_RATE)
 
     # --- 6. Training and Validation Loop ---
     start_time = time.time()

--- a/main.py
+++ b/main.py
@@ -83,8 +83,10 @@ def main():
             super(SimpleCNN, self).__init__()
             # Input: 3x32x32
             self.conv1 = nn.Conv2d(in_channels=3, out_channels=32, kernel_size=3, padding=1)
+            self.bn1 = nn.BatchNorm2d(32)
             self.pool = nn.MaxPool2d(kernel_size=2, stride=2) # Reduces size from 32x32 to 16x16
             self.conv2 = nn.Conv2d(in_channels=32, out_channels=64, kernel_size=3, padding=1)
+            self.bn2 = nn.BatchNorm2d(64)
             # Pool again, from 16x16 to 8x8
             
             # The flattened size will be 64 (channels) * 8 * 8 (image dimension)
@@ -92,8 +94,8 @@ def main():
             self.fc2 = nn.Linear(128, 10) # 10 output classes
 
         def forward(self, x):
-            x = self.pool(torch.relu(self.conv1(x)))
-            x = self.pool(torch.relu(self.conv2(x)))
+            x = self.pool(torch.relu(self.bn1(self.conv1(x))))
+            x = self.pool(torch.relu(self.bn2(self.conv2(x))))
             x = x.view(-1, 64 * 8 * 8) # Flatten the tensor
             x = torch.relu(self.fc1(x))
             x = self.fc2(x)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def main():
     BATCH_SIZE = 512
     EPOCHS = 10
     USE_BN = False  # Toggle BatchNorm on/off to isolate its effect
-    USE_COSINE = False  # Disable cosine for this experiment (fixed LR)
+    USE_COSINE = True  # Enable cosine annealing LR schedule
     
     print("Pre-loading data...")
     start_load_time = time.time()

--- a/main.py
+++ b/main.py
@@ -13,11 +13,11 @@ def main():
 
     # --- 2. Hyperparameters ---
     # These are the settings we will be tweaking in our experiments
-    LEARNING_RATE = 0.01  # Baseline SGD learning rate
+    LEARNING_RATE = 0.02  # Higher LR test for SGD momentum baseline
     BATCH_SIZE = 512
     EPOCHS = 10
     USE_BN = False  # Toggle BatchNorm on/off to isolate its effect
-    USE_COSINE = True  # Toggle cosine LR schedule for 10 epochs (no warm restarts)
+    USE_COSINE = False  # Disable cosine for this experiment (fixed LR)
     
     print("Pre-loading data...")
     start_load_time = time.time()

--- a/main.py
+++ b/main.py
@@ -105,8 +105,8 @@ def main():
 
     # --- 5. Loss Function and Optimizer ---
     criterion = nn.CrossEntropyLoss()
-    # Rollback to baseline optimizer
-    optimizer = optim.SGD(model.parameters(), lr=LEARNING_RATE)
+    # BN + SGD with momentum=0.9 (Run 8b)
+    optimizer = optim.SGD(model.parameters(), lr=LEARNING_RATE, momentum=0.9)
 
     # --- 6. Training and Validation Loop ---
     start_time = time.time()


### PR DESCRIPTION
Summary of commits between main and try-batchnorm2d:

- a509353: Initial attempt to add BatchNorm2d; observed ~50% slower training and reduced accuracy.
- 14a66b0: Added momentum with BatchNorm; surpassed earlier baseline but training remained slow.
- 810d93c: Introduced USE_BN toggle; removed BatchNorm from SimpleCNN to isolate momentum’s effect.
- 981f6ae: Experimented with adding weight decay to SGD for potential generalization gains.
- 87adb60: Added optional cosine learning rate scheduler; removed weight decay from SGD to isolate scheduler effects.
- 1c79b39: Tuned hyperparameters for momentum experiments: increased LR to 0.02 and disabled cosine schedule.
- 3382a7b: Updated README to improve onboarding and clarify experiment setup instructions.
- 22a2151: Re-enabled cosine schedule in main.py after testing; noted it did not improve results.
- 68604ee: Disabled cosine annealing LR schedule based on experimental outcomes.

Net effect

- Model/training: BatchNorm2d support added behind a flag and iterated on; momentum and weight decay combinations explored; cosine LR scheduling added, tested, then disabled due to lack of benefit.
- Documentation: README expanded for clearer setup and experiment guidance.
- Experiments: experiments.md populated with additional runs and analysis.

Files changed

- README.md: significant edits to instructions and experiment notes.
- experiments.md: appended new runs and analyses (including BatchNorm, momentum, LR schedule tests).
- main.py: added/toggled USE_BN, LR scheduler options, and optimizer hyperparameter changes.

Rationale and outcomes

- BatchNorm2d provided mixed results initially (slower, lower accuracy), then improved with momentum tuning; final recommendation is to keep BN as an optional toggle.
- Cosine LR scheduling did not yield improvements for this setup and is disabled by default.
- Documentation now better reflects how to run and compare experiments.

Breaking changes

- None to runtime interfaces; potential checkpoint incompatibility when switching BN on/off due to architectural differences.